### PR TITLE
Adjust accordion header typography

### DIFF
--- a/Accordion.liquid
+++ b/Accordion.liquid
@@ -27,11 +27,18 @@
       width: 100%;
       display: flex; align-items: center; justify-content: space-between;
       padding: 14px 0; background: transparent; border: 0; cursor: pointer; text-align: left;
-      text-transform: uppercase; letter-spacing: 1px; font-size: 12px;
     }
     .accordion-header:focus-visible { outline: 2px solid #000; outline-offset: 2px; }
 
     .accordion-icon { font-size: 16px; line-height: 1; transition: transform var(--transition); }
+
+    .pdp-scope .accordion-header {
+      font-family: 'Inter', sans-serif;
+      font-size: 1rem;
+      font-weight: 400;
+      text-transform: none;
+      letter-spacing: 0.02em;
+    }
 
     .accordion-body {
       overflow: hidden; max-height: 0; transition: max-height 0.4s ease; will-change: max-height;
@@ -44,7 +51,7 @@
 </head>
 <body>
 
-  <section class="accordion-section" aria-label="Product details">
+  <section class="accordion-section pdp-scope" aria-label="Product details">
     <!-- 1. Shipping -->
     <div class="accordion">
       <button class="accordion-header" type="button"

--- a/product.liquid
+++ b/product.liquid
@@ -117,6 +117,14 @@
   .pdp-scope .buy-now-button:hover { background: #333; }
   .pdp-scope .add-to-cart-error { color: #c62828; font-size: .9rem; margin:.5rem 0 1rem; }
 
+  .pdp-scope .accordion-header {
+    font-family: 'Inter', sans-serif;
+    font-size: 1rem;
+    font-weight: 400;
+    text-transform: none;
+    letter-spacing: 0.02em;
+  }
+
   .pdp-scope .swatch-wrapper { display: flex; align-items: center; gap: 0.4rem; margin-bottom: 1.1rem; }
   .pdp-scope .swatch { width: 26px; height: 26px; border: none; border-radius: 0; cursor: pointer; transition: outline 0.2s; background-clip: padding-box; }
   .pdp-scope .swatch.selected { outline: 1px solid #111; outline-offset: 2px; }


### PR DESCRIPTION
## Summary
- remove the uppercase, tight tracking font treatment from `.accordion-header`
- scope new typography settings to `.pdp-scope .accordion-header` per updated design guidance
- ensure the demo markup is wrapped with the `pdp-scope` class so the new styles apply

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce050710c8832f80ec11b12cced6e4