### PR TITLE
Adjust accordion header font styling

### DIFF
--- a/Accordion.liquid
+++ b/Accordion.liquid
@@ -25,9 +25,19 @@
 
     .accordion-header {
       width: 100%;
-      display: flex; align-items: center; justify-content: space-between;
-      padding: 14px 0; background: transparent; border: 0; cursor: pointer; text-align: left;
-      text-transform: uppercase; letter-spacing: 1px; font-size: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 0;
+      background: transparent;
+      border: 0;
+      cursor: pointer;
+      text-align: left;
+      font-family: 'Inter', sans-serif;
+      font-size: 1rem;
+      font-weight: 400;
+      text-transform: none;
+      letter-spacing: 0.02em;
     }
     .accordion-header:focus-visible { outline: 2px solid #000; outline-offset: 2px; }
 

--- a/product.liquid
+++ b/product.liquid
@@ -242,10 +242,11 @@
     border: 0;
     cursor: pointer;
     text-align: left;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-family: 'Inter', sans-serif;
+    font-size: 1rem;
+    font-weight: 400;
+    text-transform: none;
+    letter-spacing: 0.02em;
     color: inherit;
   }
   .pdp-scope .accordion-header:focus-visible { outline: 2px solid #000; outline-offset: 2px; }


### PR DESCRIPTION
## Summary
- update the product page accordion header typography to use Inter at 1rem with lighter tracking and normal weight
- apply the same accordion header font updates to the standalone accordion example

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce1f8755c8832f84f9c184e9fbe8a8