### PR TITLE
Scope selling points styles to product form

### DIFF
--- a/product.liquid
+++ b/product.liquid
@@ -28,6 +28,25 @@
       <p class="product-label">NEW ARRIVAL</p>
       <h1 class="product-title">CloudNine Hanging Rest Spot</h1>
       <p class="product-price">$19.99</p>
+      <div class="selling-points">
+        <div class="pdp-divider-block"></div>
+        <ul class="sp-list">
+          <li class="sp-item">
+            <span class="sp-icon">
+              <img src="{{ 'Truck.svg' | asset_url }}" alt=""/>
+            </span>
+            <span class="sp-text">Free tracked shipping on every order</span>
+          </li>
+          <li class="sp-item">
+            <span class="sp-icon dot"></span>
+            <span class="sp-text">Industrial suction cups support up to 40 lbs</span>
+          </li>
+          <li class="sp-item">
+            <span class="sp-icon dot"></span>
+            <span class="sp-text">Tool-free install sticks to any smooth surface</span>
+          </li>
+        </ul>
+      </div>
       <div class="product-rating">★★★★★ <span>(4.7)</span></div>
       <p class="product-shade" style="display:none;">Shade: <span id="selectedShade"></span></p>
 

--- a/product.liquid
+++ b/product.liquid
@@ -184,6 +184,49 @@
   .pdp-scope .product-shade { font-size: 0.85rem; margin-bottom: 0.5rem; }
   .pdp-scope .product-description { font-size: 0.9rem; line-height: 1.4; margin-bottom: 1.2rem; }
 
+  /* Selling points */
+  .pdp-scope .product-form .pdp-divider-block {
+    border-top: 1px solid #e6e6e6;
+    margin: 1.75rem 0 1.25rem;
+    padding-top: 1.25rem;
+  }
+  .pdp-scope .product-form .sp-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.85rem;
+  }
+  .pdp-scope .product-form .sp-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+  .pdp-scope .product-form .sp-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: #111;
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.85rem;
+    flex-shrink: 0;
+  }
+  .pdp-scope .product-form .sp-icon.dot {
+    width: 10px;
+    height: 10px;
+    margin-top: 0.55rem;
+    background: #111;
+    border-radius: 50%;
+  }
+  .pdp-scope .product-form .sp-text {
+    font-size: 0.9rem;
+    line-height: 1.45;
+    color: #333;
+  }
+
   .pdp-scope .atc-button { background: #fff; color: #111; border: 1px solid #111; padding: 0.75rem 1.5rem; font-size: 1rem; width: 100%; margin-bottom: 0.5rem; transition: all 0.3s ease; }
   .pdp-scope .atc-button:hover { background: #111; color: #fff; }
   .pdp-scope .buy-now-button { background: #111; color: #fff; border: none; padding: 0.75rem 1.5rem; font-size: 1rem; width: 100%; transition: background 0.3s ease; }


### PR DESCRIPTION
## Summary
- scope the selling points CSS selectors under .product-form to avoid leaking styles
- add scoped styling for the divider, list layout, icon display, and supporting text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce593af5d8832f9559d071af646525