### PR TITLE
Use rem units for highlight list typography

### DIFF
--- a/product.liquid
+++ b/product.liquid
@@ -183,6 +183,10 @@
   .pdp-scope .product-rating span { color: #aaa; margin-left: 0.25em; }
   .pdp-scope .product-shade { font-size: 0.85rem; margin-bottom: 0.5rem; }
   .pdp-scope .product-description { font-size: 0.9rem; line-height: 1.4; margin-bottom: 1.2rem; }
+  .pdp-scope .sp-list li {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
 
   .pdp-scope .atc-button { background: #fff; color: #111; border: 1px solid #111; padding: 0.75rem 1.5rem; font-size: 1rem; width: 100%; margin-bottom: 0.5rem; transition: all 0.3s ease; }
   .pdp-scope .atc-button:hover { background: #111; color: #fff; }


### PR DESCRIPTION
## Summary
- switch the .pdp-scope .sp-list list item typography to rem units so the highlights text follows the product pricing/rating scale

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce80d64f04832fa5b1a78c25e6184b